### PR TITLE
add documentation autodeployment

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -1,0 +1,32 @@
+name: Merge master
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout work branch
+        uses: actions/checkout@v3
+      - name: Build sphinx documentation
+        uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"
+      - name: Commit documentation changes
+        run: |
+          git clone https://github.com/DOE-police/DOEDA.git --branch gh-pages --single-branch gh-pages
+          cp -r docs/_build/html/* gh-pages/
+          cd gh-pages
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+          # The above command will fail if no changes were present, so we ignore
+          # the return code.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
deploys documentation when we merge changes into master
unconditionally.
We should deploy only when changes to documentation were
made to be more efficient but for the moment this will do