### PR TITLE
create .nojekyll file when deploying github pages docs

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -18,6 +18,7 @@ jobs:
           git clone https://github.com/DOE-police/DOEDA.git --branch gh-pages --single-branch gh-pages
           cp -r docs/build/html/* gh-pages/
           cd gh-pages
+          touch .nojekyll
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add .


### PR DESCRIPTION
we need this file to avoid github pages uses jekyll since
the sphinx site uses directories starting with underscore
and jekyll interprets these as special resources and
does not copy them to the final site