### PR TITLE
fix documentation deployment

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -19,6 +19,12 @@ jobs:
           cp -r docs/build/html/* gh-pages/
           cd gh-pages
           touch .nojekyll
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+          # The above command will fail if no changes were present, so we ignore
+          # the return code.
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
add commit to documentation branch so we do not lose the
built documentation changes and the documentation deployment
is properly updated