### PR TITLE
add row number when generating experiments bundle

### DIFF
--- a/utils/data_processing/generate_experiment_bundle.py
+++ b/utils/data_processing/generate_experiment_bundle.py
@@ -16,10 +16,13 @@ def generate_json_bundle(experiments_path: str):
             experiments_path += "/"
         experiments = os.listdir(experiments_path)
         experiments_dict = list()
+        file_number = 1
         for experiment in experiments:
             with open(experiments_path + experiment, "r") as yaml_doc:
                 yaml_to_dict = yaml.load(yaml_doc, Loader=yaml.FullLoader)
+                yaml_to_dict["row_number"] = file_number
                 experiments_dict.append(yaml_to_dict)
+            file_number += 1
         with open("experiments-bundle.json", "w") as json_doc:
             json.dump(experiments_dict, json_doc)
             print("✅ Experiment JSON bundle successfully generated")


### PR DESCRIPTION
we add a new surrogate key to paginate results using
s3 select since s3 select does not support sql offset
or skip commands